### PR TITLE
Feature cache individual requests responses

### DIFF
--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -175,7 +175,6 @@ module.exports = {
             headers : {
               Authorization: "Bearer " + wardenToken
             },
-            cached: false,
           };
 
           try {

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -244,6 +244,8 @@ module.exports = {
           }
 
         } catch (err) {
+          console.log('ERROR');
+          console.log(err);
           logger.error(err);
           callback(null);
         }

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -135,6 +135,7 @@ module.exports = {
         // const userList = await getUserList(wardenToken);
 
         const callData = await getCallData(wardenToken);
+        console.log(callData);
 
         /*
         try {

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -174,7 +174,8 @@ module.exports = {
             url: usersEndpointURL,
             headers : {
               Authorization: "Bearer " + wardenToken
-            }
+            },
+            cached: false,
           };
 
           try {

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -159,9 +159,8 @@ module.exports = {
       }    
     }
 
-
     function getUserList(wardenToken) {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
         if (!wardenToken) {
           reject('Error: no warden token');
         } else {

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -245,16 +245,6 @@ module.exports = {
           }
         }
       });
-      try {
-
-
-
-
-
-      } catch (err) {
-        logger.error(err);
-        callback(null);
-      }
     }
 
     function addNameToCall(call, listOfUsers){

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -133,6 +133,8 @@ module.exports = {
         const wardenToken = await wardenAuth(appToken, username, password);
 
         const userList = await getUserList(wardenToken);
+        console.log(userList);
+        /*
         const callData = await getCallData(wardenToken);
 
         try {
@@ -153,6 +155,7 @@ module.exports = {
           logger.error(err);
           jobCallback(err, null)
         }
+        */
 
       } catch (e) {
         logger.error(e);

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -222,8 +222,8 @@ module.exports = {
           const response = await request.JSON(options);
 
           // if the results are shorter than the max, there are no more results to grab
+          console.log('length');
           console.log(response.calls.length);
-          console.log(response);
           if (response.calls.length < max) {  
             if (typeof first != 'undefined') {
               // if we specified a first element, we will need to remove it from our results

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -132,11 +132,11 @@ module.exports = {
         const wardenAuth = require("../util/auth/wardenNodeAuth.js").cachedWardenAuth;
         const wardenToken = await wardenAuth(appToken, username, password);
 
-        const userList = await getUserList(wardenToken);
-        console.log(userList);
-        /*
+        // const userList = await getUserList(wardenToken);
+
         const callData = await getCallData(wardenToken);
 
+        /*
         try {
           for (call in callData.calls){
             addNameToCall(callData.calls[call],userList.users)
@@ -156,6 +156,7 @@ module.exports = {
           jobCallback(err, null)
         }
         */
+
 
       } catch (e) {
         logger.error(e);

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -219,6 +219,8 @@ module.exports = {
         };
 
         try {
+          console.log('Before the rquest');
+          console.log(request.JSON(options));
           const response = await request.JSON(options);
 
           // if the results are shorter than the max, there are no more results to grab

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -134,6 +134,8 @@ module.exports = {
 
         getUserList(wardenToken, (userList) => {
           getCallData(wardenToken, (callData) => {
+            console.log('callData');
+            console.log(callData);
             try {
               for (call in callData.calls){
                 addNameToCall(callData.calls[call],userList.users)
@@ -220,6 +222,8 @@ module.exports = {
           const response = await request.JSON(options);
 
           // if the results are shorter than the max, there are no more results to grab
+          console.log(response.calls.length);
+          console.log(response);
           if (response.calls.length < max) {  
             if (typeof first != 'undefined') {
               // if we specified a first element, we will need to remove it from our results

--- a/jobs/callData/callData.js
+++ b/jobs/callData/callData.js
@@ -132,12 +132,9 @@ module.exports = {
         const wardenAuth = require("../util/auth/wardenNodeAuth.js").cachedWardenAuth;
         const wardenToken = await wardenAuth(appToken, username, password);
 
-        // const userList = await getUserList(wardenToken);
-
+        const userList = await getUserList(wardenToken);
         const callData = await getCallData(wardenToken);
-        console.log(callData);
 
-        /*
         try {
           for (call in callData.calls){
             addNameToCall(callData.calls[call],userList.users)
@@ -156,7 +153,6 @@ module.exports = {
           logger.error(err);
           jobCallback(err, null)
         }
-        */
 
 
       } catch (e) {

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -23,7 +23,9 @@ class CacheDestroyer {
   }
 
   purge() {
+    console.log('purging...');
     const toDelKeys = this[_gatherKeysToDelete]();
+    console.log(toDelKeys);
     toDelKeys.forEach(keyToDel => this[_cache].delete(keyToDel));
   }
 }

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -1,0 +1,32 @@
+const _cache = Symbol('cache');
+const _gatherKeysToDelete = Symbol('gatherKeysToDel');
+
+const purgeExecutionInterval = 1000 * 60 * 60;
+
+class CacheDestroyer {
+  constructor(cache) {
+    this[_cache] = cache;
+
+    this[_gatherKeysToDelete] = function() {
+      const toDelKeys = [];
+      for (let [key] of this[_cache]) {
+        if (!this[_cache].get(key).stillValid()) {
+          toDelKeys.push(key);
+        }
+      }
+
+      return toDelKeys;
+    }
+
+    setInterval(() => this.purge(), purgeExecutionInterval);
+  }
+
+  purge() {
+    const toDelKeys = this[_gatherKeysToDelete]();
+    toDelKeys.forEach(keyToDel => this[_cache].delete(keyToDel));
+  }
+}
+
+module.exports = {
+  CacheDestroyer,
+}

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -1,7 +1,8 @@
 const _cache = Symbol('cache');
 const _gatherKeysToDelete = Symbol('gatherKeysToDel');
 
-const purgeExecutionInterval = 1000 * 60 * 60;
+// const purgeExecutionInterval = 1000 * 60 * 60;
+const purgeExecutionInterval = 1000 * 60;
 
 class CacheDestroyer {
   constructor(cache) {

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -40,6 +40,8 @@ class CacheDestroyer {
       clearInterval(this[_purgeOperationID]);
       this[_purgeOperationID] = undefined;
     }
+
+    this[_schedulePurge]();
   }
 
   get purgeTimeout() {

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -15,7 +15,7 @@ class CacheDestroyer {
       const toDelKeys = [];
       
       for (let [key] of this[_map]) {
-        if (!map.get(key).stillValid()) {
+        if (!this[_map].get(key).stillValid()) {
           toDelKeys.push(key);
         }
       }

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -1,5 +1,6 @@
 const _cache = Symbol('cache');
 const _gatherKeysToDelete = Symbol('gatherKeysToDel');
+const _map = Symbol('map');
 
 // const purgeExecutionInterval = 1000 * 60 * 60;
 const purgeExecutionInterval = 1000 * 60;
@@ -8,10 +9,13 @@ class CacheDestroyer {
   constructor(cache) {
     this[_cache] = cache;
 
+    this[_map] = this[_cache].getAll();
+
     this[_gatherKeysToDelete] = function() {
       const toDelKeys = [];
-      for (let [key] of this[_cache]) {
-        if (!this[_cache].get(key).stillValid()) {
+      
+      for (let [key] of this[_map]) {
+        if (!map.get(key).stillValid()) {
           toDelKeys.push(key);
         }
       }
@@ -26,7 +30,7 @@ class CacheDestroyer {
     console.log('purging...');
     const toDelKeys = this[_gatherKeysToDelete]();
     console.log(toDelKeys);
-    toDelKeys.forEach(keyToDel => this[_cache].delete(keyToDel));
+    toDelKeys.forEach(keyToDel => this[_map].delete(keyToDel));
   }
 }
 

--- a/jobs/util/cache/CacheDestroyer.js
+++ b/jobs/util/cache/CacheDestroyer.js
@@ -2,13 +2,11 @@ const _cache = Symbol('cache');
 const _gatherKeysToDelete = Symbol('gatherKeysToDel');
 const _map = Symbol('map');
 
-// const purgeExecutionInterval = 1000 * 60 * 60;
-const purgeExecutionInterval = 1000 * 60;
+const purgeExecutionInterval = 1000 * 60 * 60;
 
 class CacheDestroyer {
   constructor(cache) {
     this[_cache] = cache;
-
     this[_map] = this[_cache].getAll();
 
     this[_gatherKeysToDelete] = function() {
@@ -27,9 +25,7 @@ class CacheDestroyer {
   }
 
   purge() {
-    console.log('purging...');
     const toDelKeys = this[_gatherKeysToDelete]();
-    console.log(toDelKeys);
     toDelKeys.forEach(keyToDel => this[_map].delete(keyToDel));
   }
 }

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -81,10 +81,8 @@ class EasyRequestWrapper {
     let promise;
 
     if (!this[isCached](options)) {
-      console.log('not reusing requedst/response');
       promise = this[handleRequest](options);
     } else {
-      console.log('Reusing request/responses')
       const entry = this[cacheImplementation].get(options.url);
       if (!entry) {
         const entryValue = this[newEntry](options);

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -31,12 +31,11 @@ class EasyRequestWrapper {
       return new Promise((resolve, reject) => {
         entryValue.response
         .then((result) => {
-          console.log(result);
           this[updateEntry](options.url, result);
+          console.log('resolving result');
           resolve(result);
          })
         .catch((error) => {
-          console.log(error);
           this[updateEntry](options.url, error);
           reject(error);
         });
@@ -52,9 +51,6 @@ class EasyRequestWrapper {
 
     this[addValueToCache] = (url, value, validity = DEFAULT_TTL) => {
       const cacheEntry = new GenericCacheEntry(value, validity);
-      console.log('Setting cache entry');
-      console.log(url);
-      console.log(cacheEntry);
       this[cacheImplementation].set(url, cacheEntry);
     };
 
@@ -77,7 +73,6 @@ class EasyRequestWrapper {
       console.log('Entry located, no need to fetch again...');
     }
 
-    console.log('promise');
     console.log(promise);
     return promise;
   }

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -32,7 +32,6 @@ class EasyRequestWrapper {
         entryValue.response
         .then((result) => {
           this[updateEntry](options.url, result);
-          console.log('resolving result');
           resolve(result);
          })
         .catch((error) => {
@@ -61,19 +60,20 @@ class EasyRequestWrapper {
   }
 
   JSON(options) {
+    console.log(options.url);
     const entry = this[cacheImplementation].get(options.url);
     let promise;
     if (!entry) {
-      console.log('No entry, fetching data...');
       const entryValue = this[newEntry](options);
       this[addValueToCache](options.url, entryValue, options.ttl);
       promise = this[updateCache](options, entryValue);
     } else {
+      console.log(entry);
       promise = entry.value.response;
-      console.log('Entry located, no need to fetch again...');
     }
 
     console.log(promise);
+  
     return promise;
   }
 }

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -1,0 +1,73 @@
+const easyRequest = Symbol('easyRequest');
+const cacheImplementation = Symbol('cacheImplementation');
+const handleRequest = Symbol('handleRequest');
+const updateCache = Symbol('updateCache');
+const newEntry = Symbol('newEntry');
+
+const DEFAULT_TTL = 1000 * 60 * 60 * 24; 
+
+class EasyRequestWrapper {
+  constructor(requestApi, cache) {
+    this[easyRequest] = requestApi;
+    this[cacheImplementation] = cache;
+
+    this[handleRequest] = (options) => {
+      return new Promise((resolve, reject) => {
+        this[easyRequest].JSON(options, (err, response) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(response);
+          }
+        });
+      });
+    };
+
+    this[updateCache] = (options, entryValue) => {
+      return new Promise((resolve, reject) => {
+        entryValue.response
+        .then((result) => {
+          this[cacheImplementation].set(options.url, result);
+          resolve(result);
+         })
+        .catch((error) => {
+          this[cacheImplementation].set(option.url, error);
+          reject(error);
+        });
+      });
+
+    };
+
+    this[newEntry] = (options) => {
+      return {
+        response: this[handleRequest](options),
+        timestamp: new Date().getTime(),
+        ttl: options.ttl || DEFAULT_TTL,
+      };
+    };
+  }
+
+  JSON(options) {
+    const entry = cache.get(options.url);
+    let promise;
+    if (!entry) {
+      const entryValue = this[newEntry]();
+      this[cacheImplementation].set(options.url, entryValue);
+      promise = this[updateCache](options, entryValue);
+    } else {
+      if (entry.timestamp > (new Date().getTime() - entry.ttl)) {
+        promise = entry.response;
+      } else {
+        const entryValue = this[entryValue]();
+        this[cacheImplementation].set(options.url, entryValue);
+        promise = this[updateCache](options, entryValue);
+      }
+    }
+
+    return promise;
+  }
+}
+
+module.exports = {
+  EasyRequestWrapper
+}

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -73,7 +73,7 @@ class EasyRequestWrapper {
       this[addValueToCache](options.url, entryValue, options.ttl);
       promise = this[updateCache](options, entryValue);
     } else {
-      promise = entry.response;
+      promise = entry.value.response;
       console.log('Entry located, no need to fetch again...');
     }
 

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -17,13 +17,10 @@ class EasyRequestWrapper {
 
     this[handleRequest] = (options) => {
       return new Promise((resolve, reject) => {
-        console.log(options);
         this[easyRequest].JSON(options, (err, response) => {
           if (err) {
-            console.log(err);
             reject(err);
           } else {
-            console.log(response);
             resolve(response);
           }
         });
@@ -66,13 +63,13 @@ class EasyRequestWrapper {
     const entry = this[cacheImplementation].get(options.url);
     let promise;
     if (!entry) {
-      console.log('No entry!');
+      console.log('No entry, fetching data...');
       const entryValue = this[newEntry](options);
       this[addValueToCache](options.url, entryValue, options.ttl);
       promise = this[updateCache](options, entryValue);
-      console.log('Promise')
     } else {
       promise = entry.response;
+      console.log('Entry located, no need to fetch again...');
     }
 
     return promise;

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -44,7 +44,7 @@ class EasyRequestWrapper {
     this[newEntry] = (options) => {
       return {
         response: this[handleRequest](options),
-        timestamp: new Date().getTime(),
+        requestTimestamp: new Date().getTime(),
       };
     };
 
@@ -54,8 +54,14 @@ class EasyRequestWrapper {
     };
 
     this[updateEntry] = (url, result) => {
-      const validity = this[cacheImplementation].get(url).validity;
-      this[addValueToCache](url, result, validity);
+      const entry = this[cacheImplementation].get(url);
+      const validity = entry.validity;
+
+      const value = entry.value;
+      value.response = result;
+      value.responseTimestamp = new Date().getTime();
+
+      this[addValueToCache](url, value, validity);
     };
   }
 

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -31,10 +31,12 @@ class EasyRequestWrapper {
       return new Promise((resolve, reject) => {
         entryValue.response
         .then((result) => {
+          console.log(result);
           this[updateEntry](options.url, result);
           resolve(result);
          })
         .catch((error) => {
+          console.log(error);
           this[updateEntry](options.url, error);
           reject(error);
         });
@@ -50,6 +52,9 @@ class EasyRequestWrapper {
 
     this[addValueToCache] = (url, value, validity = DEFAULT_TTL) => {
       const cacheEntry = new GenericCacheEntry(value, validity);
+      console.log('Setting cache entry');
+      console.log(url);
+      console.log(cacheEntry);
       this[cacheImplementation].set(url, cacheEntry);
     };
 

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -63,7 +63,7 @@ class EasyRequestWrapper {
   }
 
   JSON(options) {
-    const entry = cache.get(options.url);
+    const entry = this[cacheImplementation].get(options.url);
     let promise;
     if (!entry) {
       console.log('No entry!');

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -17,10 +17,13 @@ class EasyRequestWrapper {
 
     this[handleRequest] = (options) => {
       return new Promise((resolve, reject) => {
+        console.log(options);
         this[easyRequest].JSON(options, (err, response) => {
           if (err) {
+            console.log(err);
             reject(err);
           } else {
+            console.log(response);
             resolve(response);
           }
         });
@@ -63,9 +66,11 @@ class EasyRequestWrapper {
     const entry = cache.get(options.url);
     let promise;
     if (!entry) {
+      console.log('No entry!');
       const entryValue = this[newEntry](options);
       this[addValueToCache](options.url, entryValue, options.ttl);
       promise = this[updateCache](options, entryValue);
+      console.log('Promise')
     } else {
       promise = entry.response;
     }

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -80,7 +80,7 @@ class EasyRequestWrapper {
   JSON(options) {
     let promise;
 
-    if (this[isCached](options)) {
+    if (!this[isCached](options)) {
       console.log('not reusing requedst/response');
       promise = this[handleRequest](options);
     } else {

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -81,6 +81,7 @@ class EasyRequestWrapper {
     let promise;
 
     if (this[isCached](options)) {
+      console.log('not reusing requedst/response');
       promise = this[handleRequest](options);
     } else {
       console.log('Reusing request/responses')

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -81,9 +81,9 @@ class EasyRequestWrapper {
     let promise;
 
     if (this[isCached](options)) {
-      console.log('making the rwquest');
       promise = this[handleRequest](options);
     } else {
+      console.log('Reusing request/responses')
       const entry = this[cacheImplementation].get(options.url);
       if (!entry) {
         const entryValue = this[newEntry](options);

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -81,6 +81,7 @@ class EasyRequestWrapper {
     let promise;
 
     if (this[isCached](options)) {
+      console.log('making the rwquest');
       promise = this[handleRequest](options);
     } else {
       const entry = this[cacheImplementation].get(options.url);

--- a/jobs/util/cache/EasyRequestWrapper.js
+++ b/jobs/util/cache/EasyRequestWrapper.js
@@ -72,6 +72,8 @@ class EasyRequestWrapper {
       console.log('Entry located, no need to fetch again...');
     }
 
+    console.log('promise');
+    console.log(promise);
     return promise;
   }
 }

--- a/jobs/util/cache/InMemoryCache.js
+++ b/jobs/util/cache/InMemoryCache.js
@@ -23,6 +23,10 @@ class InMemoryCache {
     return this[_singleton];
   }
 
+  getAll() {
+    return this[_cacheProp];
+  }
+
   get(key) {
     return this[_cacheProp].get(key);
   }

--- a/jobs/util/cache/InMemoryCache.js
+++ b/jobs/util/cache/InMemoryCache.js
@@ -1,54 +1,35 @@
-const cacheProp = Symbol('cache');
-const validityProp = Symbol('validity');
-const gatherKeysToDelete = Symbol('gatherKeysToDel');
-const singleton = Symbol();
-const singletonEnforcer = Symbol();
+const _cacheProp = Symbol('cache');
+const _singleton = Symbol();
+const _singletonEnforcer = Symbol();
+const _cacheDestroyer = Symbol('cacheDestroyer');
 
-const purgeExecutionInterval = 1000 * 60 * 60;
-
+const { CacheDestroyer } = require('./CacheDestroyer');
+ 
 class InMemoryCache {
   constructor(enforcer) {
-    if (enforcer !== singletonEnforcer) {
+    if (enforcer !== _singletonEnforcer) {
       throw new Error('Cannot construct a singleton object');
     }
 
-    this[cacheProp] = new Map();
-
-    this[gatherKeysToDelete] = function() {
-      const toDelKeys = [];
-      for (let [key, value] of this[cacheProp]) {
-        if (!this[cacheProp].get(key).stillValid()) {
-          toDelKeys.push(key);
-        }
-      }
-      return toDelKeys;
-    }
-
-    setInterval(() => {
-      this.purge();
-    }, purgeExecutionInterval);
+    this[_cacheProp] = new Map();
   }
 
   static get instance() {
-    if (!this[singleton]) {
-      this[singleton] = new InMemoryCache(singletonEnforcer);
+    if (!this[_singleton]) {
+      this[_singleton] = new InMemoryCache(_singletonEnforcer);
+      this[_cacheDestroyer] = new CacheDestroyer(this[_singleton]);
     }
 
-    return this[singleton];
+    return this[_singleton];
   }
 
   get(key) {
-    return this[cacheProp].get(key);
+    return this[_cacheProp].get(key);
   }
 
   set(key, value) {
     value.timestamp = new Date().getTime();
-    this[cacheProp].set(key, value);
-  }
-
-  purge() {
-    const toDelKeys = this[gatherKeysToDelete]();
-    toDelKeys.forEach(keyToDel => this[cacheProp].delete(keyToDel));
+    this[_cacheProp].set(key, value);
   }
 }
 


### PR DESCRIPTION
Added a new wrapper EasyRequestWrapper, that accepts the easyRequest dependency and the cache implementation. Currently the cache used is InMemoryCache. The .JSON function excepts the options object which needs to have:

- regular request parameters ( url, headers, etc )
- ttl ( Time To Live, how much time that request is valid )
- cached ( to use or not a cached request )

NOTE: the wrapper uses the InMemoryCache mechanism to purge data so it should rely on that for the individual entries purging . If the TTL < purgePeriod then the item is removed from cache after the purge is complete. This needs to be fine tuned according to the needs. Additional work may be necessary to prevent reuse of cached entries, or even use a cache with a second or so purge period to make sure all cached requests are cleaned before they are used.

I've adapted the callData.js job to use cached requests as a template for other implementations on other jobs.



